### PR TITLE
Pass a logger and package identifiers to `IWorkItemLinkMapper`

### DIFF
--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0002" />
     <ProjectReference Include="..\Server\Server.csproj" />
   </ItemGroup>
 </Project>

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using NSubstitute;
 using NUnit.Framework;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems;
@@ -66,7 +67,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             {
                 Comments = new [] {new JiraIssueComment { Body = string.Empty }}
             });
-            
+
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy);
 
             var workItems = mapper.Map(new OctopusBuildInformation
@@ -76,7 +77,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
                     new Commit { Id = "abcd", Comment = "This is a test commit message. Fixes JRE-1234"},
                     new Commit { Id = "defg", Comment = "This is a test commit message with duplicates. Fixes JRE-1234"}
                 }
-            });
+            }, Substitute.For<ILogWithContext>());
 
             Assert.IsTrue(workItems.Succeeded);
             Assert.AreEqual(1, workItems.Value.Length);
@@ -97,7 +98,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
             {
                 Comments = new [] {new JiraIssueComment { Body = string.Empty }}
             });
-            
+
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy);
 
             var workItems = mapper.Map(new OctopusBuildInformation
@@ -106,7 +107,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
                 {
                     new Commit { Id = "abcd", Comment = "This is a test commit message. Fixes JRE-1234"}
                 }
-            });
+            }, Substitute.For<ILogWithContext>());
 
             Assert.IsTrue(workItems.Succeeded);
             Assert.AreEqual("Jira", workItems.Value.Single().Source);

--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -7,6 +7,7 @@ using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Integration;
+using Octopus.Versioning.Semver;
 using Commit = Octopus.Server.Extensibility.HostServices.Model.IssueTrackers.Commit;
 
 namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
@@ -70,7 +71,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy);
 
-            var workItems = mapper.Map(new OctopusBuildInformation
+            var workItems = mapper.Map("P", new SemanticVersion("1"), new OctopusBuildInformation
             {
                 Commits = new Commit[]
                 {
@@ -101,7 +102,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Tests
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy);
 
-            var workItems = mapper.Map(new OctopusBuildInformation
+            var workItems = mapper.Map("P", new SemanticVersion("1"), new OctopusBuildInformation
             {
                 Commits = new Commit[]
                 {

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.2.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.1" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
   </ItemGroup>
 </Project>

--- a/source/Server/Server.csproj
+++ b/source/Server/Server.csproj
@@ -14,7 +14,7 @@
   <ItemGroup>
     <PackageReference Include="Octopus.Data" Version="4.2.1" />
     <PackageReference Include="Octopus.Diagnostics" Version="1.3.0" />
-    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0001" />
+    <PackageReference Include="Octopus.Server.Extensibility" Version="7.1.2-enh-release-crea0002" />
     <PackageReference Include="Octopus.Time" Version="1.1.6" />
   </ItemGroup>
 </Project>

--- a/source/Server/Web/JiraCredentialsConnectivityCheckAction.cs
+++ b/source/Server/Web/JiraCredentialsConnectivityCheckAction.cs
@@ -45,7 +45,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.Web
             }
 
             var jiraRestClient = new JiraRestClient(baseUrl, username, password, log);
-            var connectivityCheckResult = jiraRestClient.ConnectivityCheck().Result;
+            var connectivityCheckResult = jiraRestClient.ConnectivityCheck().GetAwaiter().GetResult();
             context.Response.AsOctopusJson(connectivityCheckResult);
         }
     }

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Text.RegularExpressions;
+using Octopus.Diagnostics;
 using Octopus.Server.Extensibility.Extensions;
 using Octopus.Server.Extensibility.Extensions.WorkItems;
 using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
@@ -28,7 +29,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
         public string CommentParser => JiraConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log)
         {
             if (!IsEnabled || 
                 string.IsNullOrEmpty(store.GetJiraUsername()) || 

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -8,6 +8,7 @@ using Octopus.Server.Extensibility.HostServices.Model.BuildInformation;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Configuration;
 using Octopus.Server.Extensibility.IssueTracker.Jira.Integration;
 using Octopus.Server.Extensibility.Resources.IssueTrackers;
+using Octopus.Versioning;
 
 namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
 {
@@ -29,7 +30,7 @@ namespace Octopus.Server.Extensibility.IssueTracker.Jira.WorkItems
         public string CommentParser => JiraConfigurationStore.CommentParser;
         public bool IsEnabled => store.GetIsEnabled();
 
-        public SuccessOrErrorResult<WorkItemLink[]> Map(OctopusBuildInformation buildInformation, ILogWithContext log)
+        public SuccessOrErrorResult<WorkItemLink[]> Map(string packageId, IVersion version, OctopusBuildInformation buildInformation, ILogWithContext log)
         {
             if (!IsEnabled || 
                 string.IsNullOrEmpty(store.GetJiraUsername()) || 


### PR DESCRIPTION
To match OctopusDeploy/ServerExtensibility#25.

Part of a solution to OctopusDeploy/Issues#5869.