### PR TITLE
Batch calls for Issues

### DIFF
--- a/source/Server.Tests/WorkItemLinkMapperScenarios.cs
+++ b/source/Server.Tests/WorkItemLinkMapperScenarios.cs
@@ -41,15 +41,32 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Tests
                     Summary = "Test title",
                     Comments = new JiraIssueComments
                     {
-                        Total = 1
+                        Total = 1,
+                        Comments = new []
+                        {
+                            new JiraIssueComment
+                            {
+                                Body = new JiraDoc
+                                {
+                                    Content = new []
+                                    {
+                                        new JiraDocContent {
+                                            Content = new []
+                                            {
+                                                new JiraDocContentElement
+                                                {
+                                                    Text = releaseNote
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
                     }
                 }
             };
-            jiraClient.GetIssue(Arg.Is(linkData)).Returns(jiraIssue);
-            jiraClient.GetIssueComments(Arg.Is(linkData)).Returns(new JiraIssueComments
-            {
-                Comments = new [] {new JiraIssueComment { Body = releaseNote }}
-            });
+            jiraClient.GetIssues(Arg.Any<string[]>()).Returns(new JiraSearchResult { Issues = new [] { jiraIssue }});
 
             return new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy, Substitute.For<ISystemLog>()).GetReleaseNote(jiraIssue, releaseNotePrefix);
         }
@@ -64,11 +81,15 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Tests
             store.GetIsEnabled().Returns(true);
             store.GetJiraUsername().Returns("user");
             store.GetJiraPassword().Returns("password".ToSensitiveString());
-            jiraClient.GetIssue(Arg.Is("JRE-1234")).Returns(new JiraIssue());
-            jiraClient.GetIssueComments(Arg.Is("JRE-1234")).Returns(new JiraIssueComments
+            var jiraIssue = new JiraIssue
             {
-                Comments = new [] {new JiraIssueComment { Body = string.Empty }}
-            });
+                Key = "JRE-1234",
+                Fields = new JiraIssueFields
+                {
+                    Comments = new JiraIssueComments()
+                }
+            };
+            jiraClient.GetIssues(Arg.Any<string[]>()).Returns(new JiraSearchResult { Issues = new [] {jiraIssue}});
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy, Substitute.For<ISystemLog>());
 
@@ -94,11 +115,15 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Tests
             store.GetIsEnabled().Returns(true);
             store.GetJiraUsername().Returns("user");
             store.GetJiraPassword().Returns("password".ToSensitiveString());
-            jiraClient.GetIssue(Arg.Is("JRE-1234")).Returns(new JiraIssue());
-            jiraClient.GetIssueComments(Arg.Is("JRE-1234")).Returns(new JiraIssueComments
+            var jiraIssue = new JiraIssue
             {
-                Comments = new [] {new JiraIssueComment { Body = string.Empty }}
-            });
+                Key = "JRE-1234",
+                Fields = new JiraIssueFields
+                {
+                    Comments = new JiraIssueComments()
+                }
+            };
+            jiraClient.GetIssues(Arg.Any<string[]>()).Returns(new JiraSearchResult { Issues = new [] { jiraIssue }});
 
             var mapper = new WorkItemLinkMapper(store, new CommentParser(), jiraClientLazy, Substitute.For<ISystemLog>());
 

--- a/source/Server/Deployments/JiraDeployment.cs
+++ b/source/Server/Deployments/JiraDeployment.cs
@@ -133,7 +133,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Deployments
                     {
                         new JiraDeploymentData
                         {
-                            DeploymentSequenceNumber = int.Parse(deployment.Id.Split('-')[1]),
+                            DeploymentSequenceNumber = int.Parse(deployment.Id!.Split('-')[1]),
                             UpdateSequenceNumber = DateTime.UtcNow.Ticks,
                             DisplayName = serverTask.Description,
                             Associations = new []

--- a/source/Server/Integration/IJiraRestClient.cs
+++ b/source/Server/Integration/IJiraRestClient.cs
@@ -6,6 +6,6 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
     interface IJiraRestClient
     {
         Task<ConnectivityCheckResponse> ConnectivityCheck();
-        Task<JiraSearchResult> GetIssues(string[] workItemId);
+        Task<JiraSearchResult?> GetIssues(string[] workItemId);
     }
 }

--- a/source/Server/Integration/IJiraRestClient.cs
+++ b/source/Server/Integration/IJiraRestClient.cs
@@ -6,7 +6,6 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
     interface IJiraRestClient
     {
         Task<ConnectivityCheckResponse> ConnectivityCheck();
-        Task<JiraIssue?> GetIssue(string workItemId);
-        Task<JiraIssueComments> GetIssueComments(string workItemId);
+        Task<JiraSearchResult> GetIssues(string[] workItemId);
     }
 }

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections.Generic;
-using System.Net;
+using System.Linq;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
@@ -70,35 +70,22 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
             return connectivityCheckResponse;
         }
 
-        public async Task<JiraIssue?> GetIssue(string workItemId)
+        public async Task<JiraSearchResult> GetIssues(string[] workItemIds)
         {
+            var workItemQuery = $"id in ({string.Join(", ", workItemIds)})";
+            var content = JsonConvert.SerializeObject(new { jql = workItemQuery, fields = new [] { "summary", "comment" } });
             var response =
-                await httpClient.GetAsync($"{baseUrl}/{baseApiUri}/issue/{workItemId}?fields=summary,comment");
+                await httpClient.PostAsync($"{baseUrl}/rest/api/3/search", new StringContent(content, Encoding.UTF8, "application/json"));
             if (response.IsSuccessStatusCode)
             {
-                var result = await GetResult<JiraIssue>(response);
-                systemLog.Info($"Retrieved Jira Work Item data for work item id {workItemId}");
+                var result = await GetResult<JiraSearchResult>(response);
+                systemLog.Info($"Retrieved Jira Work Item data for work item ids {string.Join(", ", result.Issues.Select(wi => wi.Key))}");
                 return result;
             }
 
-            var msg = $"Failed to retrieve Jira issue '{workItemId}' from {baseUrl}. Response Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})" : "")}";
+            var msg = $"Failed to retrieve Jira issues '{string.Join(", ", workItemIds)}' from {baseUrl}. Response Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})" : "")}";
             systemLog.Warn(msg);
             return null;
-        }
-
-        public async Task<JiraIssueComments> GetIssueComments(string workItemId)
-        {
-            var response = await httpClient.GetAsync($"{baseUrl}/{baseApiUri}/issue/{workItemId}/comment");
-            if (response.IsSuccessStatusCode)
-                return await GetResult<JiraIssueComments>(response);
-
-            var msg =
-                $"Failed to retrieve comments for Jira issue '{workItemId}' from {baseUrl}. Response Code: {response.StatusCode}{(!string.IsNullOrEmpty(response.ReasonPhrase) ? $" (Reason: {response.ReasonPhrase})" : "")}";
-            if (response.StatusCode == HttpStatusCode.NotFound)
-                systemLog.Trace(msg);
-            else
-                systemLog.Warn(msg);
-            return new JiraIssueComments();
         }
 
         async Task<TResult> GetResult<TResult>(HttpResponseMessage response)
@@ -110,11 +97,11 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
                 var result = JsonConvert.DeserializeObject<TResult>(content);
                 return result;
             }
-            catch
+            catch (Exception ex)
             {
                 response.Headers.TryGetValues("Content-Type", out var contentType);
                 var errMsg =
-                    $"Error parsing JSON content for type {typeof(TResult)}. Content Type: '{contentType}', content: {content}";
+                    $"Error parsing JSON content for type {typeof(TResult)}. Content Type: '{contentType}', content: {content}, error: {ex}";
                 systemLog.Error(errMsg);
                 throw;
             }
@@ -127,6 +114,12 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
             client.DefaultRequestHeaders.Authorization = authorizationHeader;
             return client;
         }
+    }
+
+    class JiraSearchResult
+    {
+        [JsonProperty("issues")]
+        public JiraIssue[] Issues { get; set; }
     }
 
     class JiraIssue
@@ -161,7 +154,30 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
     class JiraIssueComment
     {
         [JsonProperty("body")]
-        public string Body { get; set; } = string.Empty;
+        public JiraDoc? Body { get; set; }
+    }
+
+    class JiraDoc
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [JsonProperty("content")]
+        public IEnumerable<JiraDocContent> Content { get; set; }
+    }
+
+    class JiraDocContent
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [JsonProperty("content")]
+        public IEnumerable<JiraDocContentElement> Content { get; set; }
+    }
+    class JiraDocContentElement
+    {
+        [JsonProperty("type")]
+        public string Type { get; set; }
+        [JsonProperty("text")]
+        public string Text { get; set; }
     }
 
     class PermissionSettingsContainer

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -70,10 +70,10 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
             return connectivityCheckResponse;
         }
 
-        public async Task<JiraSearchResult> GetIssues(string[] workItemIds)
+        public async Task<JiraSearchResult?> GetIssues(string[] workItemIds)
         {
             var workItemQuery = $"id in ({string.Join(", ", workItemIds)})";
-            var content = JsonConvert.SerializeObject(new { jql = workItemQuery, fields = new [] { "summary", "comment" } });
+            var content = JsonConvert.SerializeObject(new { jql = workItemQuery, fields = new [] { "summary", "comment" }, maxResults = 10000 });
             var response =
                 await httpClient.PostAsync($"{baseUrl}/rest/api/3/search", new StringContent(content, Encoding.UTF8, "application/json"));
             if (response.IsSuccessStatusCode)
@@ -119,7 +119,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
     class JiraSearchResult
     {
         [JsonProperty("issues")]
-        public JiraIssue[] Issues { get; set; }
+        public JiraIssue[] Issues { get; set; } = new JiraIssue[0];
     }
 
     class JiraIssue
@@ -140,15 +140,11 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
 
     class JiraIssueComments
     {
-        public JiraIssueComments()
-        {
-            Comments = new List<JiraIssueComment>();
-        }
-
         [JsonProperty("comments")]
-        public IEnumerable<JiraIssueComment> Comments { get; set; }
+        public IEnumerable<JiraIssueComment> Comments { get; set; } = new JiraIssueComment[0];
+
         [JsonProperty("total")]
-        public int Total { get; set; }
+        public int Total { get; set; } = 0;
     }
 
     class JiraIssueComment
@@ -160,24 +156,27 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
     class JiraDoc
     {
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
+
         [JsonProperty("content")]
-        public IEnumerable<JiraDocContent> Content { get; set; }
+        public IEnumerable<JiraDocContent> Content { get; set; } = new JiraDocContent[0];
     }
 
     class JiraDocContent
     {
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
+
         [JsonProperty("content")]
-        public IEnumerable<JiraDocContentElement> Content { get; set; }
+        public IEnumerable<JiraDocContentElement> Content { get; set; } = new JiraDocContentElement[0];
     }
+
     class JiraDocContentElement
     {
         [JsonProperty("type")]
-        public string Type { get; set; }
+        public string Type { get; set; } = string.Empty;
         [JsonProperty("text")]
-        public string Text { get; set; }
+        public string Text { get; set; } = string.Empty;
     }
 
     class PermissionSettingsContainer

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -46,26 +46,38 @@ namespace Octopus.Server.Extensibility.JiraIntegration.WorkItems
                 return ResultFromExtension<WorkItemLink[]>.Failed("No BaseUrl configured");
 
             var releaseNotePrefix = store.GetReleaseNotePrefix();
-            var workItemIds = commentParser.ParseWorkItemIds(buildInformation).Distinct();
+            var workItemIds = commentParser.ParseWorkItemIds(buildInformation).Distinct().ToArray();
+            if (workItemIds.Length == 0)
+                return ResultFromExtension<WorkItemLink[]>.Success(new WorkItemLink[0]);
 
             return ResultFromExtension<WorkItemLink[]>.Success(ConvertWorkItemLinks(workItemIds, releaseNotePrefix, baseUrl));
         }
 
-        private WorkItemLink[] ConvertWorkItemLinks(IEnumerable<string> workItemIds, string? releaseNotePrefix, string baseUrl)
+        private WorkItemLink[] ConvertWorkItemLinks(string[] workItemIds, string? releaseNotePrefix, string baseUrl)
         {
-            return workItemIds.Select(workItemId =>
-                {
-                    var issue = jira.Value.GetIssue(workItemId).GetAwaiter().GetResult();
-                    if (issue is null)
-                    {
-                        systemLog.Warn($"Parsed work item id {workItemId} from commit message but was unable to locate it in Jira");
-                        return null;
-                    }
+            var issues = jira.Value.GetIssues(workItemIds.ToArray()).GetAwaiter().GetResult();
+            if (issues == null || issues.Issues.Length == 0)
+            {
+                return new WorkItemLink[0];
+            }
 
+            var issueMap = issues.Issues.ToDictionary(x => x.Key);
+
+            var workItemsNotFound = workItemIds.Where(x => !issueMap.ContainsKey(x)).ToArray();
+            if (workItemsNotFound.Length > 0)
+            {
+                systemLog.Warn($"Parsed work item ids {string.Join(", ", workItemsNotFound)} from commit messages but could not locate them in Jira");
+            }
+
+            return workItemIds
+                .Where(workItemId => issueMap.ContainsKey(workItemId))
+                .Select(workItemId =>
+                {
+                    var issue = issueMap[workItemId];
                     return new WorkItemLink
                     {
                         Id = workItemId,
-                        Description = GetReleaseNote(issue, releaseNotePrefix),
+                        Description = GetReleaseNote(issueMap[workItemId], releaseNotePrefix),
                         LinkUrl = baseUrl + "/browse/" + workItemId,
                         Source = JiraConfigurationStore.CommentParser
                     };
@@ -82,9 +94,8 @@ namespace Octopus.Server.Extensibility.JiraIntegration.WorkItems
                 return issue.Fields.Summary;
 
             var releaseNoteRegex = new Regex($"^{releaseNotePrefix}", RegexOptions.Compiled | RegexOptions.IgnoreCase);
-            var issueComments = jira.Value.GetIssueComments(issue.Key).GetAwaiter().GetResult();
 
-            var releaseNote = issueComments?.Comments.LastOrDefault(c => releaseNoteRegex.IsMatch(c.Body))?.Body;
+            var releaseNote = issue.Fields.Comments.Comments.SelectMany(x => x.Body?.Content.SelectMany(b => b.Content).Select(x => x.Text)).Where(x => !(x is null)).LastOrDefault(c => releaseNoteRegex.IsMatch(c));
             return !string.IsNullOrWhiteSpace(releaseNote)
                 ? releaseNoteRegex.Replace(releaseNote, "")?.Trim() ?? string.Empty
                 : issue.Fields.Summary ?? issue.Key;


### PR DESCRIPTION
Our original implementation would request work item (issue) details one at a time, and would make a secondary call for each work item to get it's Comments. This proved to be way too inefficient in production scenarios for a number of customers.

This PR changes the JiraRestClient to use the search api, which will allow us to return all work items in a single call. The returned data includes both the summary and the comments, so no further secondary calls are required.