### PR TITLE
Upper case the work item ids when hitting the Jira API

### DIFF
--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -72,7 +72,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
 
         public async Task<JiraSearchResult?> GetIssues(string[] workItemIds)
         {
-            var workItemQuery = $"id in ({string.Join(", ", workItemIds)})";
+            var workItemQuery = $"id in ({string.Join(", ", workItemIds.Select(x => x.ToUpper()))})";
             var content = JsonConvert.SerializeObject(new { jql = workItemQuery, fields = new [] { "summary", "comment" }, maxResults = 10000 });
             var response =
                 await httpClient.PostAsync($"{baseUrl}/rest/api/3/search", new StringContent(content, Encoding.UTF8, "application/json"));

--- a/source/Server/WorkItems/WorkItemLinkMapper.cs
+++ b/source/Server/WorkItems/WorkItemLinkMapper.cs
@@ -61,7 +61,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.WorkItems
                 return new WorkItemLink[0];
             }
 
-            var issueMap = issues.Issues.ToDictionary(x => x.Key);
+            var issueMap = issues.Issues.ToDictionary(x => x.Key, StringComparer.OrdinalIgnoreCase);
 
             var workItemsNotFound = workItemIds.Where(x => !issueMap.ContainsKey(x)).ToArray();
             if (workItemsNotFound.Length > 0)
@@ -76,7 +76,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.WorkItems
                     var issue = issueMap[workItemId];
                     return new WorkItemLink
                     {
-                        Id = workItemId,
+                        Id = issue.Key,
                         Description = GetReleaseNote(issueMap[workItemId], releaseNotePrefix),
                         LinkUrl = baseUrl + "/browse/" + workItemId,
                         Source = JiraConfigurationStore.CommentParser


### PR DESCRIPTION
Given Jira forces upper case project keys we're going to upper case all work item references we check.

The mapping code also now uses case insensitive lookups into the dictionary it is managing and is using the ids returned from Jira, not the ones parsed from the commits.