### PR TITLE
Fix for jira api when searching for work items that do not exist

### DIFF
--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -93,7 +93,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
         {
             var workItemQuery = $"id in ({string.Join(", ", workItemIds.Select(x => x.ToUpper()))})";
             var content = JsonConvert.SerializeObject(new
-                { jql = workItemQuery, fields = new[] { "summary", "comment" }, maxResults = 10000 });
+                { jql = workItemQuery, fields = new[] { "summary", "comment" }, maxResults = 10000, validateQuery = "none" });
 
             string errorMessage;
             try


### PR DESCRIPTION
- Added new param to jira api query to prevent query result validation
- Added tests coverage for queries with no matches