### PR TITLE
Fixed work item distinct clause

### DIFF
--- a/source/Server.Tests/JiraDeploymentData/JiraIssueTrackerApiDeploymentFixture.cs
+++ b/source/Server.Tests/JiraDeploymentData/JiraIssueTrackerApiDeploymentFixture.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Server.Extensibility.JiraIntegration.Configuration;
+using Octopus.Server.Extensibility.JiraIntegration.Deployments;
+using Octopus.Server.MessageContracts.Features.BuildInformation;
+using Octopus.Server.MessageContracts.Features.IssueTrackers;
+using Octopus.Server.MessageContracts.Features.Projects.Releases;
+using Octopus.Server.MessageContracts.Features.Projects.Releases.Deployments;
+
+namespace Octopus.Server.Extensibility.JiraIntegration.Tests.JiraDeploymentData
+{
+    [TestFixture]
+    public class JiraIssueTrackerApiDeploymentFixture
+    {
+        [Test]
+        public void WorkItemReferences_AcrossReleases_ShouldBeDistinct()
+        {
+            var subject = new JiraIssueTrackerApiDeployment();
+
+            var deployment = new DeploymentResource
+            {
+                Changes = new List<ReleaseChangesResource>
+                {
+                    CreateChangesForRelease("1.0.0", new Dictionary<string, string[]>{{"TestPackage1", new [] { "JIR-1", "JIR-2" }}, {"TestPackage2", new [] { "JIR-2" }}}),
+                    CreateChangesForRelease("1.0.1", new Dictionary<string, string[]>{{"TestPackage1", new [] { "JIR-2", "JIR-3" }}, {"TestPackage2", new [] { "JIR-3" }}})
+                }
+            };
+
+            var result = subject.DeploymentValues(deployment);
+            result.Should().BeEquivalentTo("JIR-1", "JIR-2", "JIR-3");
+        }
+
+        ReleaseChangesResource CreateChangesForRelease(string releaseVersion, IDictionary<string, string[]> packageIdToWorkItemIds)
+        {
+            var buildInformation = packageIdToWorkItemIds.Select(
+                    kvp => new ReleasePackageVersionBuildInformation
+                    {
+                        PackageId = kvp.Key, WorkItems = kvp.Value.Select(wi => new WorkItemLink { Source = JiraConfigurationStore.CommentParser, Id = wi }).ToArray()
+                    })
+                .ToList();
+            return new ReleaseChangesResource
+            {
+                Version = releaseVersion,
+                BuildInformation = buildInformation,
+                WorkItems = buildInformation.SelectMany(wi => wi.WorkItems).Distinct().ToList()
+            };
+        }
+    }
+}

--- a/source/Server.Tests/Server.Tests.csproj
+++ b/source/Server.Tests/Server.Tests.csproj
@@ -6,15 +6,16 @@
         <AssemblyName>Octopus.Server.Extensibility.JiraIntegration.Tests</AssemblyName>
     </PropertyGroup>
     <ItemGroup>
-        <PackageReference Include="Assent" Version="1.4.2"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1"/>
-        <PackageReference Include="NSubstitute" Version="3.1.0"/>
-        <PackageReference Include="NUnit" Version="3.13.2"/>
-        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0"/>
-        <PackageReference Include="Octokit" Version="0.32.0"/>
-        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15"/>
+        <PackageReference Include="Assent" Version="1.4.2" />
+        <PackageReference Include="FluentAssertions" Version="5.10.3" />
+        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.0.1" />
+        <PackageReference Include="NSubstitute" Version="3.1.0" />
+        <PackageReference Include="NUnit" Version="3.13.2" />
+        <PackageReference Include="NUnit3TestAdapter" Version="4.0.0" />
+        <PackageReference Include="Octokit" Version="0.32.0" />
+        <PackageReference Include="TeamCity.VSTest.TestAdapter" Version="1.0.15" />
     </ItemGroup>
     <ItemGroup>
-        <ProjectReference Include="..\Server\Server.csproj"/>
+        <ProjectReference Include="..\Server\Server.csproj" />
     </ItemGroup>
 </Project>

--- a/source/Server/Deployments/JiraIssueTrackerApiDeployment.cs
+++ b/source/Server/Deployments/JiraIssueTrackerApiDeployment.cs
@@ -15,8 +15,8 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Deployments
                     drn => drn.BuildInformation
                         .SelectMany(pm => pm.WorkItems)
                         .Where(wi => wi.Source == JiraConfigurationStore.CommentParser)
-                        .Select(wi => wi.Id)
-                        .Distinct())
+                        .Select(wi => wi.Id))
+                .Distinct()
                 .ToArray();
         }
 


### PR DESCRIPTION
Added a new test for `JiraIssueTrackerApiDeployment` to check work item references that are duplicated across multiple releases in a deployment. Fixed the Distinct, which was on the inner part of the LINQ statement rather than the outer result.

Relates to OctopusDeploy/Issues#7776