### PR TITLE
Fixed issue with the commit parser picking up dates

### DIFF
--- a/source/Server.Tests/CommentParserScenarios.cs
+++ b/source/Server.Tests/CommentParserScenarios.cs
@@ -141,6 +141,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Tests
         [TestCase("Some text test-foo-")]
         [TestCase("Something $foo-1")]
         [TestCase("Ignore refs followed by alpha chars Feature-0day")]
+        [TestCase("Some text with a date 2022-10-13")]
         // Due to relaxing the RegEx used to parse issues from comments this test case is no longer valid,
         // it's handled by us checking with the Jira instance if the issue exists, or if it doesnt exist
         // it doesn't get included in the list of work items returned to the UI

--- a/source/Server/Integration/JiraRestClient.cs
+++ b/source/Server/Integration/JiraRestClient.cs
@@ -148,17 +148,18 @@ namespace Octopus.Server.Extensibility.JiraIntegration.Integration
                 var errorResult = await GetResult<JiraErrorResult>(response);
 
                 errorMessage = $"Failed to retrieve Jira issues from {baseUrl}. Response Code: {response.StatusCode}{(errorResult?.ErrorMessages.Any() == true ? $" (Errors: {string.Join(", ", errorResult.ErrorMessages)})" : "")}";
+                systemLog.Warn(errorMessage);
             }
             catch (HttpRequestException e)
             {
                 errorMessage = $"Failed to retrieve Jira issues '{string.Join(", ", workItemIds)}' from {baseUrl}. (Reason: {e.Message})";
+                systemLog.Error($"Failed to retrieve Jira issues '{string.Join(", ", workItemIds)}' from {baseUrl}. ({e.PrettyPrint()})");
             }
             catch (TaskCanceledException e)
             {
                 errorMessage = $"Failed to retrieve Jira issues '{string.Join(", ", workItemIds)}' from {baseUrl}. (Reason: {e.Message})";
+                systemLog.Warn(errorMessage);
             }
-
-            systemLog.Warn(errorMessage);
 
             return ResultFromExtension<JiraIssue[]>.Failed(errorMessage);
         }

--- a/source/Server/WorkItems/CommentParser.cs
+++ b/source/Server/WorkItems/CommentParser.cs
@@ -9,7 +9,7 @@ namespace Octopus.Server.Extensibility.JiraIntegration.WorkItems
     {
         // Expression based on example found here https://confluence.atlassian.com/stashkb/integrating-with-custom-jira-issue-key-313460921.html?_ga=2.163394108.1696841245.1556699049-1954949426.1532303954 with modified negative lookbehind
         // with added '$' and '.' to exclude strings that look similar to Jira issues, e.g. `text that may cause confusion: $foo-1 or test.TST-01.com`
-        static readonly Regex Expression = new("(?<![A-Z0-9\\$\\.]-?)(?>[A-Z0-9]+-\\d+)(?![A-Z])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        static readonly Regex Expression = new("(?<![A-Z0-9\\$\\.]-?)(?>[A-Z][A-Z0-9]+-\\d+)(?![A-Z])", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         public string[] ParseWorkItemIds(OctopusBuildInformation buildInformation)
         {


### PR DESCRIPTION
The existing RegEx picked up dates from commits, if they were formatted with `yyyy-mm` at the start, and assumed they could be work item references. This creates an amount of noise in the deployment logs, and potential confusion if other errors occur.

This PR adjusts the RegEx to follow the Atlassian UI and documentation, which states that project keys MUST start with an alphabetical character.

Fixes OctopusDeploy/Issues#7844